### PR TITLE
feat: add Voicebox and specialized vLLM GB10 Qwen stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ Each service is in its own directory with complete documentation:
 - **Uptime Kuma** (`uptimekuma/`) - Uptime monitoring
 - **Home Assistant** (`homeassistant/`) - Home automation platform
 - **Open WebUI** (`openwebui/`) - Chat interface for OpenAI-compatible local and remote models
-- **LiteLLM** (`litellm/`) - OpenAI-compatible model proxy for Open WebUI, LM Studio, and hosted APIs
+- **LiteLLM** (`litellm/`) - OpenAI-compatible model proxy for Open WebUI, LM Studio, vLLM, and hosted APIs
 - **Obsidian Web Desktop** (`obsidian/`) - Browser-accessible Obsidian desktop for a Syncthing-backed vault
+- **Voicebox** (`voicebox/`) - Local-first AI voice studio for voice cloning, TTS, dictation, REST, and MCP
+- **vLLM GB10 Qwen 3.6** (`vllm-gb10-qwen-3.6/`) - Specialized DGX Spark / GB10 serving stack for Qwen 3.6 with configurable memory/context knobs
 
 Each service includes:
 

--- a/vllm-gb10-qwen-3.6/.env.example
+++ b/vllm-gb10-qwen-3.6/.env.example
@@ -1,0 +1,22 @@
+# Qwen3.6 vLLM configuration for DGX Spark / GB10
+QWEN36_VLLM_IMAGE=ghcr.io/aeon-7/vllm-spark-omni-q36:v1.2
+QWEN36_CONTAINER_NAME=vllm-qwen36-heretic
+QWEN36_MODELS_DIR=/srv/qwen36
+QWEN36_SERVED_MODEL_NAMES=qwen36-35b-heretic qwen36-fast qwen36-deep
+
+VLLM_HOST=0.0.0.0
+VLLM_PORT=8000
+VLLM_TENSOR_PARALLEL_SIZE=1
+VLLM_DTYPE=auto
+VLLM_QUANTIZATION=compressed-tensors
+
+# Memory/context knobs. Defaults prioritize a large-context standalone vLLM server.
+# For co-hosting another GPU workload, start around 0.70 and 131072.
+VLLM_GPU_MEMORY_UTILIZATION=0.85
+VLLM_MAX_MODEL_LEN=262144
+VLLM_MAX_NUM_SEQS=128
+VLLM_MAX_NUM_BATCHED_TOKENS=65536
+
+VLLM_SPECULATIVE_CONFIG={"method":"dflash","model":"/models/qwen36-dflash","num_speculative_tokens":15}
+VLLM_ATTENTION_BACKEND=flash_attn
+VLLM_NVIDIA_GPU_COUNT=all

--- a/vllm-gb10-qwen-3.6/README.md
+++ b/vllm-gb10-qwen-3.6/README.md
@@ -1,0 +1,61 @@
+# vLLM GB10 Qwen 3.6 Stack
+
+Specialized DGX Spark / GB10 vLLM deployment for `AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4` with the DFlash drafter.
+
+This is intentionally **not** a generic vLLM template. It documents a hardware- and model-specific serving profile where the image, model layout, quantization settings, speculative drafter, and memory/context knobs are expected to move together.
+
+## What this stack assumes
+
+- Host: DGX Spark / GB10 with NVIDIA Container Toolkit.
+- Model files already exist under `${QWEN36_MODELS_DIR}`:
+  - `qwen36-nvfp4` → mounted as `/models/qwen36`
+  - `qwen36-dflash` → mounted as `/models/qwen36-dflash`
+- The service uses `network_mode: host` and exposes vLLM on `${VLLM_PORT}`.
+- Defaults prioritize a large-context standalone vLLM server.
+
+## Quick start
+
+```bash
+cp vllm-gb10-qwen-3.6/.env.example vllm-gb10-qwen-3.6/.env
+# edit vllm-gb10-qwen-3.6/.env if changing memory/context
+
+docker compose --env-file vllm-gb10-qwen-3.6/.env -f vllm-gb10-qwen-3.6/docker-compose.yml up -d
+```
+
+## Memory/context knobs
+
+The defaults prioritize one large vLLM server:
+
+```bash
+VLLM_GPU_MEMORY_UTILIZATION=0.85
+VLLM_MAX_MODEL_LEN=262144
+VLLM_MAX_NUM_SEQS=128
+VLLM_MAX_NUM_BATCHED_TOKENS=65536
+```
+
+A high `VLLM_GPU_MEMORY_UTILIZATION` value lets vLLM reserve most available GPU memory for weights, CUDA graphs, and KV cache. For co-hosting Voicebox, start with:
+
+```bash
+VLLM_GPU_MEMORY_UTILIZATION=0.70
+VLLM_MAX_MODEL_LEN=131072
+```
+
+If Voicebox still hits CUDA OOM during model load, lower further to `0.65` or reduce `VLLM_MAX_NUM_SEQS`.
+
+## Validation
+
+```bash
+curl -fsS http://127.0.0.1:${VLLM_PORT:-8000}/health
+curl -fsS http://127.0.0.1:${VLLM_PORT:-8000}/v1/models | python3 -m json.tool
+curl -fsS http://127.0.0.1:${VLLM_PORT:-8000}/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"qwen36-fast","messages":[{"role":"user","content":"What is 17 * 23? Answer with just the number."}],"max_tokens":64,"temperature":0,"chat_template_kwargs":{"enable_thinking":false}}'
+```
+
+Expected arithmetic answer: `391`.
+
+## Notes
+
+- `VLLM_SPECULATIVE_CONFIG` is passed through the container environment so JSON quoting survives Compose interpolation.
+- `VLLM_TEST_FORCE_FP8_MARLIN=1` is intentional for the current NVFP4 MoE path on this image.
+- `QWEN36_CONTAINER_NAME` defaults to `vllm-qwen36-heretic`; change it if that name conflicts with an existing deployment.

--- a/vllm-gb10-qwen-3.6/docker-compose.yml
+++ b/vllm-gb10-qwen-3.6/docker-compose.yml
@@ -1,0 +1,48 @@
+# Qwen3.6-35B-A3B-heretic NVFP4 + DFlash on DGX Spark / GB10
+services:
+  vllm:
+    image: ${QWEN36_VLLM_IMAGE:-ghcr.io/aeon-7/vllm-spark-omni-q36:v1.2}
+    container_name: ${QWEN36_CONTAINER_NAME:-vllm-qwen36-heretic}
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+      TORCH_MATMUL_PRECISION: high
+      PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+      NVIDIA_FORWARD_COMPAT: "1"
+      VLLM_TEST_FORCE_FP8_MARLIN: "1"
+      VLLM_SPECULATIVE_CONFIG: ${VLLM_SPECULATIVE_CONFIG:-{"method":"dflash","model":"/models/qwen36-dflash","num_speculative_tokens":15}}
+    volumes:
+      - ${QWEN36_MODELS_DIR:-/srv/qwen36}/qwen36-nvfp4:/models/qwen36:ro
+      - ${QWEN36_MODELS_DIR:-/srv/qwen36}/qwen36-dflash:/models/qwen36-dflash:ro
+    command:
+      - bash
+      - -c
+      - |
+        exec vllm serve /models/qwen36 \
+          --served-model-name ${QWEN36_SERVED_MODEL_NAMES:-qwen36-35b-heretic qwen36-fast qwen36-deep} \
+          --host ${VLLM_HOST:-0.0.0.0} --port ${VLLM_PORT:-8000} \
+          --tensor-parallel-size ${VLLM_TENSOR_PARALLEL_SIZE:-1} \
+          --dtype ${VLLM_DTYPE:-auto} \
+          --quantization ${VLLM_QUANTIZATION:-compressed-tensors} \
+          --max-model-len ${VLLM_MAX_MODEL_LEN:-262144} \
+          --max-num-seqs ${VLLM_MAX_NUM_SEQS:-128} \
+          --max-num-batched-tokens ${VLLM_MAX_NUM_BATCHED_TOKENS:-65536} \
+          --gpu-memory-utilization ${VLLM_GPU_MEMORY_UTILIZATION:-0.85} \
+          --enable-chunked-prefill \
+          --enable-prefix-caching \
+          --load-format safetensors \
+          --trust-remote-code \
+          --enable-auto-tool-choice \
+          --tool-call-parser qwen3_coder \
+          --reasoning-parser qwen3 \
+          --speculative-config "$$VLLM_SPECULATIVE_CONFIG" \
+          --attention-backend ${VLLM_ATTENTION_BACKEND:-flash_attn}
+    ipc: host
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: ${VLLM_NVIDIA_GPU_COUNT:-all}
+              capabilities: [gpu]

--- a/voicebox/.env.example
+++ b/voicebox/.env.example
@@ -1,0 +1,24 @@
+# Voicebox configuration
+# Official Docker docs: https://docs.voicebox.sh/overview/docker
+TZ=Europe/Zurich
+VOICEBOX_HOSTNAME=voicebox.example.com
+
+# Host-side API port. Keep loopback-only when routed through Traefik.
+# On hosts without a local reverse proxy, set VOICEBOX_BIND_IP=0.0.0.0 and expose only on a trusted/VPN network.
+VOICEBOX_BIND_IP=127.0.0.1
+VOICEBOX_PORT=17493
+
+# Upstream currently documents source-build Docker. Override this to a local checkout
+# when validating builds without refetching GitHub every time.
+VOICEBOX_BUILD_CONTEXT=https://github.com/jamiepine/voicebox.git#main
+
+# Runtime logging and browser origins.
+VOICEBOX_LOG_LEVEL=info
+VOICEBOX_CORS_ORIGINS=https://voicebox.example.com
+
+# Official docs say 8GB RAM minimum and 16GB+ recommended for multiple engines.
+VOICEBOX_CPU_LIMIT=4
+VOICEBOX_MEMORY_LIMIT=16G
+
+# NVIDIA GPU reservation. Use "all" only when this stack should see every GPU.
+VOICEBOX_NVIDIA_GPU_COUNT=1

--- a/voicebox/README.md
+++ b/voicebox/README.md
@@ -1,0 +1,98 @@
+# Voicebox Stack
+
+Voicebox is a local-first AI voice studio for voice cloning, text-to-speech, dictation, and MCP/REST voice I/O. This Stacksmith service runs the headless Docker web UI/API behind Traefik.
+
+Official docs:
+
+- [Voicebox Docker deployment](https://docs.voicebox.sh/overview/docker)
+- [Voicebox GPU acceleration](https://docs.voicebox.sh/overview/gpu-acceleration)
+- [Voicebox MCP server](https://docs.voicebox.sh/overview/mcp-server)
+- [Voicebox API](https://voicebox.sh/#api)
+
+## What this stack assumes
+
+- Voicebox runs on a Docker host with the NVIDIA Container Toolkit installed when GPU acceleration is desired.
+- Browser/API access is routed through Traefik on the `stacksmith` network.
+- The direct API port defaults to host loopback only: `${VOICEBOX_BIND_IP:-127.0.0.1}:${VOICEBOX_PORT}:17493`.
+- Voicebox has no built-in authentication, so it should stay Tailscale/VPN-only or sit behind an auth middleware before broader exposure.
+- Upstream Docker currently builds from source; prebuilt GHCR images are documented as coming later, not available now.
+
+## Quick start
+
+1. Copy the environment template:
+
+```bash
+cp voicebox/.env.example voicebox/.env
+```
+
+2. Edit `voicebox/.env`:
+
+```bash
+VOICEBOX_HOSTNAME=voicebox.yourdomain.com
+VOICEBOX_CORS_ORIGINS=https://voicebox.yourdomain.com
+VOICEBOX_MEMORY_LIMIT=16G
+VOICEBOX_NVIDIA_GPU_COUNT=1
+```
+
+3. Build and start Voicebox:
+
+```bash
+docker compose --env-file voicebox/.env -f voicebox/docker-compose.yml up -d --build
+```
+
+4. Open the UI through Traefik:
+
+```text
+https://voicebox.yourdomain.com
+```
+
+5. Check the local API from the Docker host:
+
+```bash
+curl -fsS http://127.0.0.1:${VOICEBOX_PORT:-17493}/health
+curl -fsS http://127.0.0.1:${VOICEBOX_PORT:-17493}/profiles
+```
+
+## Resource guidance
+
+Voicebox docs call out **8GB RAM minimum** and **16GB+ recommended** for running multiple engines. If Voicebox shares a GPU host with a vLLM server, lower the vLLM reservation first; a practical starting point is:
+
+```bash
+VLLM_GPU_MEMORY_UTILIZATION=0.70
+VLLM_MAX_MODEL_LEN=131072
+```
+
+That preserves a long-context serving profile while creating materially more headroom for Voicebox model loading and CUDA/PyTorch runtime overhead.
+
+## API / MCP
+
+Voicebox exposes REST and MCP on port `17493`:
+
+```bash
+curl -X POST http://127.0.0.1:17493/speak \
+  -H "Content-Type: application/json" \
+  -H "X-Voicebox-Client-Id: hermes" \
+  -d '{"text":"Deploy complete.","profile":"Morgan"}'
+```
+
+Documented MCP endpoint:
+
+```text
+http://127.0.0.1:17493/mcp
+```
+
+Tools include `voicebox.speak`, `voicebox.transcribe`, `voicebox.list_profiles`, and `voicebox.list_captures`.
+
+## Volumes
+
+| Volume | Container path | Purpose |
+|---|---|---|
+| `stacksmith_voicebox_data` | `/app/data` | Profiles, database, app data |
+| `stacksmith_voicebox_generations` | `/app/data/generations` | Generated audio files |
+| `stacksmith_voicebox_huggingface_cache` | `/home/voicebox/.cache/huggingface` | Model cache |
+
+## Notes
+
+- First build can take several minutes because it builds the frontend and installs Python/TTS dependencies.
+- Model downloads are persisted in the HuggingFace cache volume.
+- If CUDA out-of-memory errors appear, reduce the vLLM GPU reservation and/or Voicebox memory pressure before blaming Voicebox itself.

--- a/voicebox/docker-compose.yml
+++ b/voicebox/docker-compose.yml
@@ -1,0 +1,58 @@
+services:
+  voicebox:
+    build:
+      context: ${VOICEBOX_BUILD_CONTEXT:-https://github.com/jamiepine/voicebox.git#main}
+    container_name: stacksmith_voicebox
+    restart: unless-stopped
+    environment:
+      LOG_LEVEL: ${VOICEBOX_LOG_LEVEL:-info}
+      NUMBA_CACHE_DIR: /tmp/numba_cache
+      TZ: ${TZ:-Europe/Zurich}
+      VOICEBOX_CORS_ORIGINS: ${VOICEBOX_CORS_ORIGINS:-}
+    ports:
+      - ${VOICEBOX_BIND_IP:-127.0.0.1}:${VOICEBOX_PORT:-17493}:17493
+    volumes:
+      - voicebox-data:/app/data
+      - voicebox-generations:/app/data/generations
+      - voicebox-huggingface-cache:/home/voicebox/.cache/huggingface
+    networks:
+      - stacksmith
+    healthcheck:
+      test:
+        - CMD
+        - curl
+        - -f
+        - http://127.0.0.1:17493/health
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    deploy:
+      resources:
+        limits:
+          cpus: "${VOICEBOX_CPU_LIMIT:-4}"
+          memory: ${VOICEBOX_MEMORY_LIMIT:-16G}
+        reservations:
+          devices:
+            - driver: nvidia
+              count: ${VOICEBOX_NVIDIA_GPU_COUNT:-1}
+              capabilities: [gpu]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.voicebox.rule=Host(`${VOICEBOX_HOSTNAME}`)"
+      - "traefik.http.routers.voicebox.entrypoints=websecure-tailscale"
+      - "traefik.http.routers.voicebox.tls.certresolver=stacksmith"
+      - "traefik.http.services.voicebox.loadbalancer.server.port=17493"
+      - "traefik.http.routers.voicebox.middlewares=secure-headers@docker"
+
+volumes:
+  voicebox-data:
+    name: stacksmith_voicebox_data
+  voicebox-generations:
+    name: stacksmith_voicebox_generations
+  voicebox-huggingface-cache:
+    name: stacksmith_voicebox_huggingface_cache
+
+networks:
+  stacksmith:
+    external: true


### PR DESCRIPTION
## Summary
- add a Voicebox Stacksmith service following the official Docker docs
- add a deliberately specialized vLLM GB10 Qwen 3.6 stack with configurable memory/context knobs
- document generic vLLM headroom settings for co-hosting Voicebox or other GPU workloads

## Validation
- docker compose config --quiet for voicebox
- docker compose config --quiet for vllm-gb10-qwen-3.6 with VLLM_GPU_MEMORY_UTILIZATION=0.70 and VLLM_MAX_MODEL_LEN=131072
- built the upstream Voicebox Docker image locally
- ran a throwaway Voicebox container locally; /health returned healthy CPU-backend JSON

## Privacy / portability
- no hostnames, local deployment paths, private machine names, or deployment-specific memory observations are documented
- examples use generic hostnames and paths suitable for a public Stacksmith template
- the vLLM stack name and README explicitly mark it as hardware/model-specific rather than a generic vLLM template